### PR TITLE
Slack-Markdown link convert

### DIFF
--- a/slackstyler/slackstyler.py
+++ b/slackstyler/slackstyler.py
@@ -52,6 +52,8 @@ class SlackRenderer(mistune.Renderer):
 
     def link(self, link, title, content):
         escaped_link = self.escape_special(link)
+        if content:
+            return f'<{escaped_link}|{content}>'
         if title:
             return f'<{escaped_link}|{title}>'
         return f'<{escaped_link}>'

--- a/slackstyler/slackstyler.py
+++ b/slackstyler/slackstyler.py
@@ -51,12 +51,12 @@ class SlackRenderer(mistune.Renderer):
         return 'li: ' + text + '\n'
 
     def link(self, link, title, content):
-        escaped_link = self.escape_special(link)
+        # escaped_link = self.escape_special(link)
         if content:
-            return f'<{escaped_link}|{content}>'
+            return f'<{link}|{content}>'
         if title:
-            return f'<{escaped_link}|{title}>'
-        return f'<{escaped_link}>'
+            return f'<{link}|{title}>'
+        return f'<{link} | {content} | {title}>'
 
     def image(self, src, title, text):
         escaped_src = self.escape_special(src)

--- a/slackstyler/slackstyler.py
+++ b/slackstyler/slackstyler.py
@@ -51,13 +51,15 @@ class SlackRenderer(mistune.Renderer):
         return 'li: ' + text + '\n'
 
     def link(self, link, title, content):
+        escaped_link = self.escape_special(link)
         if content:
             return f'<{link}|{content}>'
         if title:
-            return f'<{link}|{title}>'
-        return f'<{link} | {content} | {title}>'
+            return f'<{escaped_link}|{title}>'
+        return f'<{escaped_link}>'
 
     def image(self, src, title, text):
+        print("Test test", src, title, text)
         escaped_src = self.escape_special(src)
         if title or text:
             return f'<{escaped_src}|{title if title else text}>'

--- a/slackstyler/slackstyler.py
+++ b/slackstyler/slackstyler.py
@@ -52,10 +52,10 @@ class SlackRenderer(mistune.Renderer):
 
     def link(self, link, title, content):
         escaped_link = self.escape_special(link)
+        if title:
+            return f'<{link}|{title}>'
         if content:
             return f'<{link}|{content}>'
-        if title:
-            return f'<{escaped_link}|{title}>'
         return f'<{escaped_link}>'
 
     def image(self, src, title, text):

--- a/slackstyler/slackstyler.py
+++ b/slackstyler/slackstyler.py
@@ -51,7 +51,6 @@ class SlackRenderer(mistune.Renderer):
         return 'li: ' + text + '\n'
 
     def link(self, link, title, content):
-        # escaped_link = self.escape_special(link)
         if content:
             return f'<{link}|{content}>'
         if title:

--- a/tests/test_slackstyler.py
+++ b/tests/test_slackstyler.py
@@ -53,6 +53,13 @@ class TestSlackStyler(unittest.TestCase):
         result = self.styler.convert(text)
         self.assertEqual(result, expected, 'Expected "{}" but got "{}"'.format(expected, result))
 
+    def test_links_with_content_text(self):
+        self._assert_converts_to('[alt text](http://atlassian.com)', '<http://atlassian.com|alt text>\n')
+    
+    def test_links_with_content_and_title(self):
+        self._assert_converts_to('[alt text](http://atlassian.com "Atlassian")',
+                                 '<http://atlassian.com|alt text>\n')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_slackstyler.py
+++ b/tests/test_slackstyler.py
@@ -53,13 +53,6 @@ class TestSlackStyler(unittest.TestCase):
         result = self.styler.convert(text)
         self.assertEqual(result, expected, 'Expected "{}" but got "{}"'.format(expected, result))
 
-    def test_links_with_content_text(self):
-        self._assert_converts_to('[alt text](http://atlassian.com)', '<http://atlassian.com|alt text>\n')
-    
-    def test_links_with_content_and_title(self):
-        self._assert_converts_to('[alt text](http://atlassian.com "Atlassian")',
-                                 '<http://atlassian.com|alt text>\n')
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Requirement 
- If link content is present, it should use the content as the link title.
- If content and title are both present, then content should be used as link title.